### PR TITLE
Fix B, C button mappings

### DIFF
--- a/client/controller.cpp
+++ b/client/controller.cpp
@@ -11,8 +11,8 @@
       DigitalControl("Up"   , report, 1, 4, true), \
       DigitalControl("Start", report, 1, 3, true), \
       DigitalControl("A"    , report, 1, 2, true), \
-      DigitalControl("B"    , report, 1, 1, true), \
-      DigitalControl("C"    , report, 1, 0, true), \
+      DigitalControl("B"    , report, 1, 0, true), \
+      DigitalControl("C"    , report, 1, 1, true), \
       DigitalControl("RT"   , report, 2, 7, true), \
       DigitalControl("X"    , report, 2, 6, true), \
       DigitalControl("Y"    , report, 2, 5, true), \

--- a/client/peripheral.cpp
+++ b/client/peripheral.cpp
@@ -13,8 +13,8 @@
       controls.push_back(new DigitalControl("Up"   , report, 1, 4, true)); \
       controls.push_back(new DigitalControl("Start", report, 1, 3, true)); \
       controls.push_back(new DigitalControl("A"    , report, 1, 2, true)); \
-      controls.push_back(new DigitalControl("B"    , report, 1, 1, true)); \
-      controls.push_back(new DigitalControl("C"    , report, 1, 0, true)); \
+      controls.push_back(new DigitalControl("B"    , report, 1, 0, true)); \
+      controls.push_back(new DigitalControl("C"    , report, 1, 1, true)); \
       controls.push_back(new DigitalControl("RT"   , report, 2, 7, true)); \
       controls.push_back(new DigitalControl("X"    , report, 2, 6, true)); \
       controls.push_back(new DigitalControl("Y"    , report, 2, 5, true)); \


### PR DESCRIPTION
In testing with fighting games, where this is pretty obvious, I noticed that the B and C mappings are reversed. It's always possible this is a quirk of my padulator and not the software though?