### PR TITLE
Makefile: mark keymap as a phony target

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -18,6 +18,8 @@ else
 LDFLAGS=$(LIBS)
 endif
 
+.PHONY: keymap
+
 client: client.cpp peripheral.cpp binding.cpp peripheral.h binding.h keymap.cpp hid.o usb.cpp
 	g++ $(CXXFLAGS) usb.cpp peripheral.cpp binding.cpp client.cpp hid.o -o client $(LDFLAGS)
 


### PR DESCRIPTION
Without this, make will assume that the `keymap` file is built from the `keymap.cpp` source file, which is why it prints this warning:

```
make: Circular keymap <- keymap.cpp dependency dropped.
```