### PR TITLE
Add an InputGamepad class to binding

### DIFF
--- a/client/binding.cpp
+++ b/client/binding.cpp
@@ -52,3 +52,31 @@ bool InputKeyboard::add_mapping(const char *inspec, Control *ctl) {
 
     return true;
 }
+
+std::multimap<SDL_GameControllerButton, DigitalControl*> InputGamepad::mapping = {};
+
+void InputGamepad::handle_event(SDL_Event *event) {
+    if (event->type != SDL_CONTROLLERBUTTONDOWN &&
+        event->type != SDL_CONTROLLERBUTTONUP)
+        return;
+
+    SDL_ControllerButtonEvent button_event = event->cbutton;
+
+    bool pressed = button_event.state == SDL_PRESSED;
+    SDL_GameControllerButton button = (SDL_GameControllerButton)button_event.button;
+
+    if (pressed)
+        std::cerr << "Button: " << SDL_GameControllerGetStringForButton(button) << std::endl;
+
+    auto its = mapping.equal_range(button);
+    for (auto it = its.first; it != its.second; ++it)
+        it->second->set(pressed);
+}
+
+bool InputGamepad::add_mapping(SDL_GameControllerButton inspec, Control *ctl) {
+    mapping.insert(std::make_pair(inspec, static_cast<DigitalControl*>(ctl)));
+
+    std::cerr << "mapped key " << SDL_GameControllerGetStringForButton(inspec) << std::endl;
+
+    return true;
+}

--- a/client/binding.cpp
+++ b/client/binding.cpp
@@ -95,7 +95,8 @@ void InputGamepad::handle_axis_event(SDL_ControllerAxisEvent event) {
         if (id != event.which)
             return;
 
-        ctl->set(event.value);
+        Uint16 value = event.value + 32768;
+        ctl->set(value / 256);
     }
 }
 

--- a/client/binding.h
+++ b/client/binding.h
@@ -13,3 +13,10 @@ public:
     static bool add_mapping(const char *inspec, Control *ctl);
     static void handle_event(SDL_Event *event);
 };
+
+class InputGamepad : public Input {
+    static std::multimap<SDL_GameControllerButton, DigitalControl*> mapping;
+public:
+    static bool add_mapping(SDL_GameControllerButton inspec, Control *ctl);
+    static void handle_event(SDL_Event *event);
+};

--- a/client/binding.h
+++ b/client/binding.h
@@ -15,8 +15,12 @@ public:
 };
 
 class InputGamepad : public Input {
-    static std::multimap<SDL_GameControllerButton, DigitalControl*> mapping;
+    static std::multimap<SDL_GameControllerButton, Control*> mapping;
+    static std::multimap<SDL_GameControllerAxis, Control*> axismapping;
 public:
     static bool add_mapping(SDL_GameControllerButton inspec, Control *ctl);
+    static bool add_axis_mapping(SDL_GameControllerAxis inspec, Control *ctl);
     static void handle_event(SDL_Event *event);
+    static void handle_button_event(SDL_ControllerButtonEvent event);
+    static void handle_axis_event(SDL_ControllerAxisEvent event);
 };

--- a/client/binding.h
+++ b/client/binding.h
@@ -15,11 +15,11 @@ public:
 };
 
 class InputGamepad : public Input {
-    static std::multimap<SDL_GameControllerButton, Control*> mapping;
-    static std::multimap<SDL_GameControllerAxis, Control*> axismapping;
+    static std::multimap<SDL_GameControllerButton, std::pair<SDL_JoystickID, Control*>> mapping;
+    static std::multimap<SDL_GameControllerAxis, std::pair<SDL_JoystickID, Control*>> axismapping;
 public:
-    static bool add_mapping(SDL_GameControllerButton inspec, Control *ctl);
-    static bool add_axis_mapping(SDL_GameControllerAxis inspec, Control *ctl);
+    static bool add_mapping(SDL_GameControllerButton inspec, SDL_JoystickID id, Control *ctl);
+    static bool add_axis_mapping(SDL_GameControllerAxis inspec, SDL_JoystickID id, Control *ctl);
     static void handle_event(SDL_Event *event);
     static void handle_button_event(SDL_ControllerButtonEvent event);
     static void handle_axis_event(SDL_ControllerAxisEvent event);


### PR DESCRIPTION
This adds a gamepad input class to the binding code. It supports SDL game controllers, and works with both digital and analogue controls. Sample code for using it (hardcoded to controller number 0) looks like this:

```c++
    if (!SDL_IsGameController(0)) {
        sdl_die("No controller 0 found");
    }

    SDL_GameController *pad = SDL_GameControllerOpen(0);
    SDL_JoystickID ctl = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(pad));
    Peripheral *p1 = new AnalogPad();
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_DPAD_RIGHT, ctl, p1->get_control("right"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_DPAD_LEFT, ctl, p1->get_control("left"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_DPAD_UP, ctl, p1->get_control("up"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_DPAD_DOWN, ctl, p1->get_control("down"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_START, ctl, p1->get_control("start"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_A, ctl, p1->get_control("A"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_B, ctl, p1->get_control("B"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_LEFTSHOULDER, ctl, p1->get_control("C"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_X, ctl, p1->get_control("X"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_Y, ctl, p1->get_control("Y"));
    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, ctl, p1->get_control("Z"));
    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTX, ctl, p1->get_control("Xaxis"));
    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTY, ctl, p1->get_control("Yaxis"));
```

The `mapped key` output looks like this:

```
mapped key dpright
mapped key dpleft
mapped key dpup
mapped key dpdown
mapped key start
mapped key a
mapped key b
mapped key leftshoulder
mapped key x
mapped key y
mapped key rightshoulder
mapped axis leftx
mapped axis lefty
```

Since the mapping takes the controller input, this supports arbitrary numbers of SDL game controllers and addresses them individually. I'm not submitting my sample gamepad client in this PR; I want to do some more work on getting the L and R axes working before that.