### PR TITLE
Add twin sticks support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /client/client
 /client/client.dSYM
 /client/keymap.cpp
+/client/twinsticks
+/client/twinsticks.dSYM
 
 # pademu
 /pademu/build

--- a/client/Makefile
+++ b/client/Makefile
@@ -24,6 +24,9 @@ endif
 client: client.cpp peripheral.cpp binding.cpp peripheral.h binding.h keymap.cpp hid.o usb.cpp
 	g++ $(CXXFLAGS) usb.cpp peripheral.cpp binding.cpp client.cpp hid.o -o client $(LDFLAGS)
 
+twinsticks: twinsticks.cpp peripheral.cpp binding.cpp peripheral.h binding.h keymap.cpp hid.o usb.cpp
+	g++ $(CXXFLAGS) usb.cpp peripheral.cpp binding.cpp twinsticks.cpp hid.o -o twinsticks $(LDFLAGS)
+
 hid.o: rawhid/$(hid_target)
 	cc $(CFLAGS) -c $< -o $@
 

--- a/client/peripheral.cpp
+++ b/client/peripheral.cpp
@@ -75,6 +75,25 @@ AnalogPad::AnalogPad()
     report[5] = report[6] = 0x00; // inactive
 }
 
+TwinStick::TwinStick()
+    : Peripheral(0, 2)
+{
+    controls.push_back(new DigitalControl("Lright"  , report, 1, 7, true));
+    controls.push_back(new DigitalControl("Lleft"   , report, 1, 6, true));
+    controls.push_back(new DigitalControl("Ldown"   , report, 1, 5, true));
+    controls.push_back(new DigitalControl("Lup"     , report, 1, 4, true));
+    controls.push_back(new DigitalControl("Lbutton" , report, 2, 7, true));
+    controls.push_back(new DigitalControl("Ltrigger", report, 2, 3, true));
+    controls.push_back(new DigitalControl("Start"   , report, 1, 3, true));
+    controls.push_back(new DigitalControl("Rright"  , report, 2, 4, true));
+    controls.push_back(new DigitalControl("Rleft"   , report, 2, 6, true));
+    controls.push_back(new DigitalControl("Rdown"   , report, 1, 0, true));
+    controls.push_back(new DigitalControl("Rup"     , report, 2, 5, true));
+    controls.push_back(new DigitalControl("Rbutton" , report, 1, 1, true));
+    controls.push_back(new DigitalControl("Rtrigger", report, 1, 2, true));
+    report[1] = report[2] = 0xff;
+}
+
 // saturn_scancodes: map from Saturn scancodes to SDL keynames
 #include "keymap.cpp"
 

--- a/client/peripheral.h
+++ b/client/peripheral.h
@@ -128,6 +128,12 @@ public:
     AnalogPad();
 };
 
+// Virtual On Twin Stick, not the Mission Stick in dual mode
+class TwinStick : public Peripheral {
+public:
+    TwinStick();
+};
+
 class Keyboard : public Peripheral {
     uint8_t scancode;
     uint8_t pending;

--- a/client/twinsticks.cpp
+++ b/client/twinsticks.cpp
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <iostream>
+#include <unistd.h>
+#include <SDL2/SDL.h>
+#include "binding.h"
+#include "peripheral.h"
+#include "usb.h"
+
+void sdl_die(const char *msg) {
+    printf("ERROR: %s: %s\n", msg, SDL_GetError());
+    exit(1);
+}
+
+
+int main(int argc, char **argv) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER))
+        sdl_die("SDL_Init failed");
+
+    SDL_Window *win = SDL_CreateWindow("Saturn Twin Stick Client", 100, 100, 320, 200, SDL_WINDOW_SHOWN);
+    if (!win)
+        sdl_die("SDL_CreateWindow failed");
+
+    SDL_Renderer *ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!ren)
+        sdl_die("SDL_CreateRenderer failed");
+
+    if (!SDL_IsGameController(0)) {
+        sdl_die("No controller 0 found");
+    }
+
+    SDL_GameController *pad = SDL_GameControllerOpen(0);
+    SDL_JoystickID ctl = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(pad));
+    Peripheral *p1 = new TwinStick();
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTX, ctl,
+                                   p1->get_control("Lleft"), -1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTX, ctl,
+                                   p1->get_control("Lright"), 1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTY, ctl,
+                                   p1->get_control("Lup"), -1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_LEFTY, ctl,
+                                   p1->get_control("Ldown"), 1);
+    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_LEFTSHOULDER, ctl,
+                              p1->get_control("Lbutton"));
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_TRIGGERLEFT, ctl,
+                                   p1->get_control("Ltrigger"));
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_RIGHTX, ctl,
+                                   p1->get_control("Rleft"), -1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_RIGHTX, ctl,
+                                   p1->get_control("Rright"), 1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_RIGHTY, ctl,
+                                   p1->get_control("Rup"), -1);
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_RIGHTY, ctl,
+                                   p1->get_control("Rdown"), 1);
+    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, ctl,
+                              p1->get_control("Rbutton"));
+    InputGamepad::add_axis_mapping(SDL_CONTROLLER_AXIS_TRIGGERRIGHT, ctl,
+                                   p1->get_control("Rtrigger"));
+    InputGamepad::add_mapping(SDL_CONTROLLER_BUTTON_START, ctl,
+                              p1->get_control("start"));
+
+    Padulator *usb = new Padulator();
+
+    SDL_Event ev;
+    while (SDL_WaitEvent(&ev)) {
+        if (ev.type == SDL_QUIT)
+            break;
+
+        if (ev.type == SDL_WINDOWEVENT &&
+            ev.window.event == SDL_WINDOWEVENT_EXPOSED) {
+            SDL_RenderClear(ren);
+            SDL_RenderPresent(ren);
+            continue;
+        }
+
+        InputGamepad::handle_event(&ev);
+        p1->sdl_event(&ev);
+
+        {
+        Report r = p1->make_report();
+        for (int i=0; i<r.size; i++)
+            printf(" %02x", r.data[i]);
+        printf("\n");
+        usb->send_report(0, r);
+        }
+    }
+}


### PR DESCRIPTION
It turns out the Virtual On twin sticks are actually treated internally as a gamepad, just with an alternate control layout. Technically they could just get treated as a gamepad here, but having appropriate symbolic names to map to is a lot more convenient.

Note that this isn't the dual mission stick - that's a different device, with analogue joysticks. This is a pure digital device.